### PR TITLE
change from using which to using hash

### DIFF
--- a/bashfiles
+++ b/bashfiles
@@ -386,7 +386,8 @@ function bf_md5() {
 
     # Provide checksum progress using `pv` if `pv` is present and we're above
     # the minimum size cut-off
-    if [[ -n `which pv` && $size -ge BF_CHECKSUM_PROGRESS_MIN_SIZE ]]; then
+    hash pv > /dev/null 2>&1
+    if [[ $? -eq 0 && $size -ge BF_CHECKSUM_PROGRESS_MIN_SIZE ]]; then
         cmd="pv $filename | "
     else
         cmd="cat $filename | "


### PR DESCRIPTION
which was noisy on a box without pv which lead me to want to change it.
which is also not recommended to be used in scripts since return code
and output isn't necessarily guaranteed. Since we're on bash its safer
to use hash, which is a built-in which will speed all this up.

For more context: https://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script